### PR TITLE
Update slapd-backup to avoid trailing slashes in S3_PATH

### DIFF
--- a/image/service/slapd-backup/assets/tool/slapd-backup
+++ b/image/service/slapd-backup/assets/tool/slapd-backup
@@ -20,7 +20,7 @@ chmod 600 $backupFilePath
 
 if [[ "$UPLOAD_TO_S3" == "true" ]]; then
   # Upload backup to S3. The backupFilePath is the config backup file path
-  aws s3 cp $backupFilePath s3://${S3_PATH}/
+  aws s3 cp $backupFilePath s3://$(echo $S3_PATH | sed 's:/*$::')/
   echo "Upload successful"
 fi
 


### PR DESCRIPTION
Remove trailing slashes of S3_PATH to avoid uploading backup to 's3://bucket/path//' which creates a directory called '/' in the bucket.