### PR TITLE
use recent AWS CLI version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project follows [osixia/openldap](https://github.com/osixia/docker-openldap-backup) versioning.
 
+## [1.5.1] - unpublished
+### Changed
+  - Upgrade awscli to recent version for better support of AWS EKS
+
 ## [1.5.0] - 2021-02-19
 ### Changed
   - Upgrade baseimage to openldap:1.5.0

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -6,9 +6,10 @@ FROM osixia/openldap:1.5.0
 #          https://github.com/osixia/docker-light-baseimage/blob/master/image/service-available/:cron/download.sh
 RUN apt-get -y update \
 	&& /container/tool/add-multiple-process-stack \
-	&& apt-get install -y awscli \
+	&& apt-get install -y python3-pip \
 	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+	&& pip3 install awscli==1.20.24
 
 # Add service directory to /container/service
 ADD service /container/service


### PR DESCRIPTION
I propose to use a newer version of the AWS CLI for writing the S3 backups.

When running Kubernetes with AWS EKS, there is a standard way of mapping Kubernetes service accounts to AWS roles:
https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
Unfortunately, this depends on having a more recent version of the CLI, the currently installed version 1.16 (via apt and debian:buster) does not work for me.

The fix is to install a current version via pip3.